### PR TITLE
Update tests to match corrections to UEB punctuation symbols

### DIFF
--- a/spec/features/home/index_spec.rb
+++ b/spec/features/home/index_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'As a visitor', type: :feature do
       end
 
       it 'I should see the Braille corresponding to my text' do
-        unicode_string = '⠠⠓⠑⠇⠇⠕⠠⠀⠠⠺⠕⠗⠇⠙⠖'
+        unicode_string = '⠠⠓⠑⠇⠇⠕⠂ ⠠⠺⠕⠗⠇⠙⠖'
         expect(page).to have_content(unicode_string)
       end
     end

--- a/spec/features/home/index_spec.rb
+++ b/spec/features/home/index_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'As a visitor', type: :feature do
       end
 
       it 'I should see the Braille corresponding to my text' do
-        unicode_string = '⠠⠓⠑⠇⠇⠕⠠⠀⠠⠺⠕⠗⠇⠙⠮'
+        unicode_string = '⠠⠓⠑⠇⠇⠕⠠⠀⠠⠺⠕⠗⠇⠙⠖'
         expect(page).to have_content(unicode_string)
       end
     end

--- a/spec/models/braille_transformer_spec.rb
+++ b/spec/models/braille_transformer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BrailleTransformer, type: :model do
       it 'can take an english string and return same string in grade 1 braille' do
         string = "Hello, World!"
         transformer = BrailleTransformer.new(string)
-        expected = "⠠⠓⠑⠇⠇⠕⠠⠀⠠⠺⠕⠗⠇⠙⠖"
+        expected = "⠠⠓⠑⠇⠇⠕⠂ ⠠⠺⠕⠗⠇⠙⠖"
         expect(transformer.grade_1_braille).to eq(expected)
       end
     end

--- a/spec/models/braille_transformer_spec.rb
+++ b/spec/models/braille_transformer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BrailleTransformer, type: :model do
       it 'can take an english string and return same string in grade 1 braille' do
         string = "Hello, World!"
         transformer = BrailleTransformer.new(string)
-        expected = "⠠⠓⠑⠇⠇⠕⠠⠀⠠⠺⠕⠗⠇⠙⠮"
+        expected = "⠠⠓⠑⠇⠇⠕⠠⠀⠠⠺⠕⠗⠇⠙⠖"
         expect(transformer.grade_1_braille).to eq(expected)
       end
     end


### PR DESCRIPTION
RSpec results:
```
Finished in 0.26124 seconds (files took 2.28 seconds to load)
19 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/turing/2module
/exercises/ruby_on_brailles/coverage. 128 / 128 LOC (100.0%) covered.
```